### PR TITLE
Refine equipment handling and add crafting interactions

### DIFF
--- a/src/modules/crafting.js
+++ b/src/modules/crafting.js
@@ -1,11 +1,18 @@
-import { subscribe } from "../state/store.js";
+import { actions, subscribe } from "../state/store.js";
 import { createElement, clearChildren } from "../ui/dom.js";
+
+const formatItemStats = (item) => {
+  if (!item || !Array.isArray(item.stats) || item.stats.length === 0) {
+    return ["No explicit modifiers."];
+  }
+  return item.stats;
+};
 
 export class CraftingPanel {
   constructor() {
     this.element = createElement("div", { className: "panel", attrs: { "data-area": "crafting" } });
-    this.element.appendChild(createElement("h2", { text: "Crafting Materials" }));
-    this.content = createElement("div", { className: "currency-grid" });
+    this.element.appendChild(createElement("h2", { text: "Crafting Bench" }));
+    this.content = createElement("div", { className: "crafting-content" });
     this.element.appendChild(this.content);
     this.unsubscribe = null;
   }
@@ -24,20 +31,116 @@ export class CraftingPanel {
 
   render(state) {
     clearChildren(this.content);
+
+    const craftingState = state.crafting ?? {};
+    const { benchItem, selectedMaterialId, lastCraftSummary } = craftingState;
+    const selectedMaterial = state.currency.find((entry) => entry.id === selectedMaterialId);
+
+    const materialsSection = createElement("div", { className: "crafting-materials" });
+    materialsSection.appendChild(createElement("h3", { text: "Materials" }));
+
     if (!state.currency || state.currency.length === 0) {
-      this.content.appendChild(
+      materialsSection.appendChild(
         createElement("div", {
-          className: "empty-state",
+          className: "empty-state subtle",
           text: "No currency stored yet. Map rewards will accumulate here.",
         }),
       );
-      return;
+    } else {
+      const materialList = createElement("div", { className: "crafting-material-list" });
+      state.currency.forEach((material) => {
+        const isSelected = material.id === selectedMaterialId;
+        const button = createElement("button", {
+          className: `material-button${isSelected ? " selected" : ""}${material.amount <= 0 ? " depleted" : ""}`,
+        });
+        button.appendChild(createElement("div", { className: "material-name", text: material.name }));
+        button.appendChild(createElement("div", { className: "material-amount", text: `x${material.amount}` }));
+        button.addEventListener("click", () => actions.setSelectedCraftingMaterial(material.id));
+        materialList.appendChild(button);
+      });
+      materialsSection.appendChild(materialList);
     }
-    state.currency.forEach((currency) => {
-      const tile = createElement("div", { className: "currency-tile" });
-      tile.appendChild(createElement("div", { html: `<strong>${currency.name}</strong>` }));
-      tile.appendChild(createElement("div", { text: `x${currency.amount}` }));
-      this.content.appendChild(tile);
-    });
+
+    const benchSection = createElement("div", { className: "crafting-bench" });
+    benchSection.appendChild(createElement("h3", { text: "Bench" }));
+
+    const benchSlots = createElement("div", { className: "crafting-bench-slots" });
+    const itemSlot = createElement("div", { className: `bench-slot${benchItem ? " filled" : ""}` });
+    if (benchItem) {
+      itemSlot.appendChild(
+        createElement("div", { className: `bench-item-name rarity-${benchItem.rarity ?? "common"}`, text: benchItem.name }),
+      );
+      if (benchItem.baseLabel) {
+        itemSlot.appendChild(createElement("div", { className: "bench-item-base", text: benchItem.baseLabel }));
+      }
+    } else {
+      itemSlot.appendChild(
+        createElement("div", {
+          className: "bench-placeholder",
+          text: "Select an item from your stash or equipment to work on.",
+        }),
+      );
+    }
+    benchSlots.appendChild(itemSlot);
+    benchSection.appendChild(benchSlots);
+
+    const materialInfo = createElement("div", { className: "bench-material-info" });
+    if (selectedMaterial) {
+      materialInfo.textContent = `Selected Material: ${selectedMaterial.name} (x${selectedMaterial.amount})`;
+    } else {
+      materialInfo.textContent = "Selected Material: None";
+    }
+    benchSection.appendChild(materialInfo);
+
+    const benchControls = createElement("div", { className: "crafting-controls" });
+    const craftButton = createElement("button", { text: "Craft" });
+    craftButton.disabled = !benchItem || !selectedMaterial || selectedMaterial.amount <= 0;
+    craftButton.addEventListener("click", () => actions.craftBenchItem());
+    benchControls.appendChild(craftButton);
+
+    if (benchItem) {
+      const removeButton = createElement("button", { text: "Remove Item" });
+      removeButton.addEventListener("click", () => actions.returnBenchItem());
+      benchControls.appendChild(removeButton);
+    }
+
+    benchSection.appendChild(benchControls);
+
+    if (lastCraftSummary) {
+      const summary = createElement("div", {
+        className: "crafting-last-result",
+        text: `Applied ${lastCraftSummary.materialName} to ${lastCraftSummary.itemName}.`,
+      });
+      benchSection.appendChild(summary);
+    }
+
+    const statsSection = createElement("div", { className: "crafting-item-stats" });
+    statsSection.appendChild(createElement("h3", { text: "Active Item Stats" }));
+    const statsContent = createElement("div", { className: "crafting-item-stats-content" });
+    if (benchItem) {
+      statsContent.appendChild(
+        createElement("div", { className: `bench-item-name rarity-${benchItem.rarity ?? "common"}`, text: benchItem.name }),
+      );
+      if (benchItem.baseLabel) {
+        statsContent.appendChild(createElement("div", { className: "bench-item-base", text: benchItem.baseLabel }));
+      }
+      const statsList = createElement("ul", { className: "bench-stats-list" });
+      formatItemStats(benchItem).forEach((line) => {
+        statsList.appendChild(createElement("li", { text: line }));
+      });
+      statsContent.appendChild(statsList);
+    } else {
+      statsContent.appendChild(
+        createElement("div", {
+          className: "bench-placeholder",
+          text: "Place an item in the bench to view its modifiers.",
+        }),
+      );
+    }
+    statsSection.appendChild(statsContent);
+
+    this.content.appendChild(materialsSection);
+    this.content.appendChild(benchSection);
+    this.content.appendChild(statsSection);
   }
 }

--- a/src/modules/equipment.js
+++ b/src/modules/equipment.js
@@ -1,10 +1,9 @@
-import { ITEM_TYPES } from "../state/loot.js";
+import { EQUIPMENT_SLOTS } from "../state/loot.js";
 import { actions, subscribe } from "../state/store.js";
 import { createElement, clearChildren } from "../ui/dom.js";
-import { parseDragData } from "../ui/drag.js";
-import { buildItemTooltip } from "../ui/items.js";
+import { buildItemTooltip, openItemOptionsTooltip, closeItemTooltip } from "../ui/items.js";
 
-const SLOT_LABELS = ITEM_TYPES.reduce((map, slot) => {
+const SLOT_LABELS = EQUIPMENT_SLOTS.reduce((map, slot) => {
   map[slot.id] = slot.label;
   return map;
 }, {});
@@ -32,6 +31,7 @@ export class EquipmentPanel {
 
   render(state) {
     clearChildren(this.content);
+    closeItemTooltip();
     const hero = state.guild.find((h) => h.id === state.activeHeroId);
 
     if (!hero) {
@@ -46,7 +46,13 @@ export class EquipmentPanel {
 
     const grid = createElement("div", { className: "equipment-grid" });
 
-    ITEM_TYPES.forEach((slot) => {
+    const stashHasSpace = state.stash.tabs.some((tab) => tab.grid.some((cell) => cell === null));
+    const benchOccupied = Boolean(state.crafting?.benchItem);
+    const mainHandItem = hero.equipment.mainHand;
+    const mainHandIsTwoHanded = Boolean(mainHandItem && (mainHandItem.hands ?? 0) === 2);
+    const mainHandAllowsQuiver = Boolean(mainHandItem?.allowsQuiver);
+
+    EQUIPMENT_SLOTS.forEach((slot) => {
       const equippedItem = hero.equipment[slot.id];
       const slotElement = createElement("div", {
         className: `equipment-slot${equippedItem ? " filled" : ""}`,
@@ -59,52 +65,43 @@ export class EquipmentPanel {
       });
       slotElement.appendChild(label);
 
-      slotElement.addEventListener("dragover", (event) => {
-        const payload = parseDragData(event);
-        if (!payload || equippedItem) return;
-        if (payload.type === "stash-item" && payload.itemType === slot.id) {
-          event.preventDefault();
-          slotElement.classList.add("drag-over");
-        }
-      });
-
-      slotElement.addEventListener("dragleave", () => {
-        slotElement.classList.remove("drag-over");
-      });
-
-      slotElement.addEventListener("drop", (event) => {
-        const payload = parseDragData(event);
-        slotElement.classList.remove("drag-over");
-        if (!payload || equippedItem) return;
-        if (payload.type === "stash-item" && payload.itemType === slot.id) {
-          event.preventDefault();
-          actions.equipItemFromStash(payload.tabId, payload.index, slot.id);
-        }
-      });
-
       if (equippedItem) {
         const itemElement = createElement("div", {
           className: `equipment-item rarity-${equippedItem.rarity ?? "common"}`,
           text: equippedItem.name,
-          attrs: { draggable: "true" },
         });
         itemElement.title = buildItemTooltip(equippedItem);
-        itemElement.addEventListener("dragstart", (event) => {
-          event.dataTransfer.effectAllowed = "move";
-          event.dataTransfer.setData(
-            "application/json",
-            JSON.stringify({
-              type: "equipment-item",
-              slotId: slot.id,
-              itemType: equippedItem.type,
-            }),
-          );
+        itemElement.addEventListener("click", (event) => {
+          event.stopPropagation();
+          openItemOptionsTooltip({
+            anchor: itemElement,
+            item: equippedItem,
+            options: [
+              {
+                label: "Unequip to stash",
+                disabled: !stashHasSpace,
+                hint: stashHasSpace ? undefined : "No space available in stash.",
+                onSelect: () => actions.unequipItemToStash(slot.id),
+              },
+              {
+                label: "Move to crafting bench",
+                disabled: benchOccupied,
+                hint: benchOccupied ? "Bench already contains an item." : undefined,
+                onSelect: () => actions.placeItemInBenchFromEquipment(slot.id),
+              },
+            ],
+          });
         });
         slotElement.appendChild(itemElement);
       } else {
         const hint = createElement("div", {
           className: "slot-hint",
-          text: "Drag matching loot here",
+          text:
+            slot.id === "offHand" && mainHandIsTwoHanded
+              ? "Main hand item requires both hands."
+              : slot.id === "quiver" && !mainHandAllowsQuiver
+              ? "Equip a bow to use a quiver."
+              : "Click stash items to equip.",
         });
         slotElement.appendChild(hint);
       }

--- a/src/state/loot.js
+++ b/src/state/loot.js
@@ -1,20 +1,37 @@
 const randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
 
-const ITEM_TYPES = [
+export const EQUIPMENT_SLOTS = [
   { id: "helmet", label: "Helmet" },
   { id: "chest", label: "Chest Armour" },
-  { id: "ring", label: "Ring" },
-  { id: "amulet", label: "Amulet" },
-  { id: "belt", label: "Belt" },
-  { id: "sword", label: "Sword" },
-  { id: "wand", label: "Wand" },
-  { id: "bow", label: "Bow" },
-  { id: "axe", label: "Axe" },
-  { id: "mace", label: "Mace" },
-  { id: "staff", label: "Staff" },
-  { id: "shield", label: "Shield" },
-  { id: "boots", label: "Boots" },
   { id: "gloves", label: "Gloves" },
+  { id: "boots", label: "Boots" },
+  { id: "belt", label: "Belt" },
+  { id: "amulet", label: "Amulet" },
+  { id: "ring", label: "Ring" },
+  { id: "mainHand", label: "Main Hand" },
+  { id: "offHand", label: "Off-Hand" },
+  { id: "quiver", label: "Quiver" },
+];
+
+const ITEM_BASES = [
+  { id: "helmet", label: "Helmet", slots: ["helmet"] },
+  { id: "chest", label: "Chest Armour", slots: ["chest"] },
+  { id: "gloves", label: "Gloves", slots: ["gloves"] },
+  { id: "boots", label: "Boots", slots: ["boots"] },
+  { id: "belt", label: "Belt", slots: ["belt"] },
+  { id: "amulet", label: "Amulet", slots: ["amulet"] },
+  { id: "ring", label: "Ring", slots: ["ring"] },
+  { id: "sword", label: "Sword", slots: ["mainHand", "offHand"], hands: 1 },
+  { id: "axe", label: "Axe", slots: ["mainHand", "offHand"], hands: 1 },
+  { id: "mace", label: "Mace", slots: ["mainHand", "offHand"], hands: 1 },
+  { id: "wand", label: "Wand", slots: ["mainHand", "offHand"], hands: 1 },
+  { id: "staff", label: "Warstaff", slots: ["mainHand"], hands: 2 },
+  { id: "bow", label: "Longbow", slots: ["mainHand"], hands: 2, allowsQuiver: true },
+  { id: "greatsword", label: "Greatsword", slots: ["mainHand"], hands: 2 },
+  { id: "poleaxe", label: "Poleaxe", slots: ["mainHand"], hands: 2 },
+  { id: "warhammer", label: "Warhammer", slots: ["mainHand"], hands: 2 },
+  { id: "shield", label: "Shield", slots: ["offHand"] },
+  { id: "quiver", label: "Quiver", slots: ["quiver"] },
 ];
 
 const PREFIX_TEMPLATES = [
@@ -135,7 +152,7 @@ const buildRareName = (baseLabel) => {
 const generateItemId = () => `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 
 export const createRandomItem = (mapTier) => {
-  const base = ITEM_TYPES[randomInt(0, ITEM_TYPES.length - 1)];
+  const base = ITEM_BASES[randomInt(0, ITEM_BASES.length - 1)];
   const rarity = determineRarity(mapTier);
 
   let prefixCount = 0;
@@ -169,6 +186,9 @@ export const createRandomItem = (mapTier) => {
     id: generateItemId(),
     type: base.id,
     baseLabel: base.label,
+    allowedSlots: [...(base.slots ?? [])],
+    hands: base.hands ?? 0,
+    allowsQuiver: Boolean(base.allowsQuiver),
     rarity,
     name,
     stats,
@@ -184,4 +204,4 @@ export const rollLoot = (mapTier) => {
   return Array.from({ length: dropCount }, () => createRandomItem(mapTier));
 };
 
-export { ITEM_TYPES };
+export { ITEM_BASES };

--- a/src/ui/items.js
+++ b/src/ui/items.js
@@ -1,8 +1,168 @@
+import { createElement, clearChildren } from "./dom.js";
+
+let activeTooltip = null;
+let cleanupTooltipHandlers = null;
+
+const closeTooltipHandlers = () => {
+  if (cleanupTooltipHandlers) {
+    cleanupTooltipHandlers();
+    cleanupTooltipHandlers = null;
+  }
+};
+
+export const closeItemTooltip = () => {
+  if (activeTooltip) {
+    activeTooltip.remove();
+    activeTooltip = null;
+  }
+  closeTooltipHandlers();
+};
+
+const formatStatLines = (item) => {
+  if (!item || !Array.isArray(item.stats) || item.stats.length === 0) {
+    return ["No explicit modifiers."];
+  }
+  return item.stats;
+};
+
 export const buildItemTooltip = (item) => {
   if (!item) return "";
   const lines = [item.name];
-  if (item.stats && item.stats.length > 0) {
-    lines.push("", ...item.stats);
+  if (item.baseLabel) {
+    lines.push(item.baseLabel);
   }
+  if (item.rarity) {
+    lines.push(`Rarity: ${item.rarity}`);
+  }
+  lines.push("", ...formatStatLines(item));
   return lines.join("\n");
+};
+
+const positionTooltip = (tooltip, anchor) => {
+  const anchorRect = anchor.getBoundingClientRect();
+  const { innerWidth, innerHeight } = window;
+  const tooltipRect = tooltip.getBoundingClientRect();
+  const spacing = 12;
+
+  let top = window.scrollY + anchorRect.top;
+  let left = window.scrollX + anchorRect.right + spacing;
+
+  if (left + tooltipRect.width > window.scrollX + innerWidth - spacing) {
+    left = window.scrollX + anchorRect.left - tooltipRect.width - spacing;
+  }
+  if (left < window.scrollX + spacing) {
+    left = window.scrollX + spacing;
+  }
+
+  if (top + tooltipRect.height > window.scrollY + innerHeight - spacing) {
+    top = window.scrollY + innerHeight - tooltipRect.height - spacing;
+  }
+  if (top < window.scrollY + spacing) {
+    top = window.scrollY + spacing;
+  }
+
+  tooltip.style.left = `${left}px`;
+  tooltip.style.top = `${top}px`;
+};
+
+const attachGlobalHandlers = (anchor) => {
+  const handlePointerDown = (event) => {
+    if (!activeTooltip) return;
+    if (activeTooltip.contains(event.target) || anchor.contains(event.target)) {
+      return;
+    }
+    closeItemTooltip();
+  };
+  const handleScroll = () => closeItemTooltip();
+  const handleResize = () => closeItemTooltip();
+
+  document.addEventListener("pointerdown", handlePointerDown, true);
+  window.addEventListener("scroll", handleScroll, true);
+  window.addEventListener("resize", handleResize, true);
+
+  cleanupTooltipHandlers = () => {
+    document.removeEventListener("pointerdown", handlePointerDown, true);
+    window.removeEventListener("scroll", handleScroll, true);
+    window.removeEventListener("resize", handleResize, true);
+  };
+};
+
+const renderItemDetails = (container, item) => {
+  clearChildren(container);
+  if (!item) {
+    container.appendChild(createElement("div", { className: "item-tooltip-empty", text: "No item selected." }));
+    return;
+  }
+  container.appendChild(
+    createElement("div", {
+      className: `item-tooltip-name rarity-${item.rarity ?? "common"}`,
+      text: item.name,
+    }),
+  );
+  if (item.baseLabel) {
+    container.appendChild(
+      createElement("div", {
+        className: "item-tooltip-base",
+        text: item.baseLabel,
+      }),
+    );
+  }
+  const stats = formatStatLines(item);
+  const list = createElement("ul", { className: "item-tooltip-stats" });
+  stats.forEach((stat) => {
+    list.appendChild(createElement("li", { text: stat }));
+  });
+  container.appendChild(list);
+};
+
+export const openItemOptionsTooltip = ({ anchor, item, options }) => {
+  if (!anchor) return;
+  closeItemTooltip();
+
+  activeTooltip = createElement("div", { className: "item-tooltip" });
+  activeTooltip.appendChild(createElement("div", { className: "item-tooltip-content" }));
+  const content = activeTooltip.firstChild;
+  renderItemDetails(content, item);
+
+  const actionsContainer = createElement("div", { className: "item-tooltip-actions" });
+  options
+    .filter(Boolean)
+    .forEach((option) => {
+      const actionRow = createElement("div", { className: "item-tooltip-action-row" });
+      const button = createElement("button", {
+        className: "item-tooltip-action",
+        text: option.label,
+      });
+      if (option.disabled) {
+        button.disabled = true;
+      }
+      button.addEventListener("click", (event) => {
+        event.stopPropagation();
+        if (option.disabled) return;
+        closeItemTooltip();
+        option.onSelect?.();
+      });
+      actionRow.appendChild(button);
+      if (option.hint) {
+        actionRow.appendChild(createElement("div", { className: "item-tooltip-hint", text: option.hint }));
+      }
+      actionsContainer.appendChild(actionRow);
+    });
+
+  if (!actionsContainer.hasChildNodes()) {
+    actionsContainer.appendChild(
+      createElement("div", { className: "item-tooltip-hint", text: "No actions available." }),
+    );
+  }
+
+  activeTooltip.appendChild(actionsContainer);
+  document.body.appendChild(activeTooltip);
+
+  // Position after insertion to measure dimensions accurately.
+  positionTooltip(activeTooltip, anchor);
+
+  // Prevent the tooltip from closing when interacting with its contents.
+  activeTooltip.addEventListener("pointerdown", (event) => event.stopPropagation());
+
+  attachGlobalHandlers(anchor);
 };

--- a/styles/main.css
+++ b/styles/main.css
@@ -211,12 +211,14 @@ button:disabled {
   border-radius: 3px;
   background: rgba(245, 212, 143, 0.12);
   border: 1px solid rgba(204, 172, 101, 0.35);
-  cursor: grab;
+  cursor: pointer;
   user-select: none;
+  transition: transform 0.15s ease, border-color 0.15s ease;
 }
 
-.stash-item:active {
-  cursor: grabbing;
+.stash-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(245, 212, 143, 0.6);
 }
 
 .stash-item.rarity-common {
@@ -291,12 +293,14 @@ button:disabled {
   border: 1px solid rgba(204, 172, 101, 0.35);
   text-align: center;
   font-size: 0.85rem;
-  cursor: grab;
+  cursor: pointer;
   user-select: none;
+  transition: transform 0.15s ease, border-color 0.15s ease;
 }
 
-.equipment-item:active {
-  cursor: grabbing;
+.equipment-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(245, 212, 143, 0.6);
 }
 
 .equipment-item.rarity-magic {
@@ -322,6 +326,249 @@ button:disabled {
   border-radius: 8px;
   border: 1px solid rgba(204, 172, 101, 0.3);
   padding: 10px;
+}
+
+.item-tooltip {
+  position: absolute;
+  z-index: 2000;
+  background: rgba(18, 14, 11, 0.97);
+  border: 1px solid rgba(245, 212, 143, 0.4);
+  border-radius: 10px;
+  padding: 12px 14px;
+  min-width: 240px;
+  max-width: 280px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+  color: #f5ecd7;
+}
+
+.item-tooltip-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-bottom: 1px solid rgba(204, 172, 101, 0.2);
+  padding-bottom: 8px;
+  margin-bottom: 10px;
+}
+
+.item-tooltip-name {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.rarity-common {
+  color: #d4cbb6;
+}
+
+.rarity-magic {
+  color: #7fb3ff;
+}
+
+.rarity-rare {
+  color: #f7d776;
+}
+
+.item-tooltip-base {
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.item-tooltip-stats {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: #dacfba;
+}
+
+.item-tooltip-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.item-tooltip-action-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.item-tooltip-action {
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  gap: 6px;
+  background: rgba(245, 212, 143, 0.18);
+  border: 1px solid rgba(245, 212, 143, 0.35);
+  color: #f5ecd7;
+}
+
+.item-tooltip-action:hover {
+  background: rgba(245, 212, 143, 0.28);
+}
+
+.item-tooltip-action:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.item-tooltip-hint {
+  font-size: 0.75rem;
+  color: rgba(245, 212, 143, 0.65);
+}
+
+.crafting-content {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.crafting-materials,
+.crafting-bench,
+.crafting-item-stats {
+  background: rgba(21, 17, 14, 0.6);
+  border: 1px solid rgba(204, 172, 101, 0.2);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.crafting-materials h3,
+.crafting-bench h3,
+.crafting-item-stats h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #f5d48f;
+  border-bottom: 1px solid rgba(204, 172, 101, 0.2);
+  padding-bottom: 6px;
+}
+
+.crafting-material-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 8px;
+}
+
+.material-button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 8px 10px;
+  background: rgba(245, 212, 143, 0.1);
+  border: 1px solid rgba(204, 172, 101, 0.3);
+  border-radius: 8px;
+  cursor: pointer;
+  color: inherit;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+}
+
+.material-button:hover {
+  background: rgba(245, 212, 143, 0.18);
+  transform: translateY(-1px);
+}
+
+.material-button.selected {
+  border-color: rgba(245, 212, 143, 0.7);
+  box-shadow: 0 0 12px rgba(245, 212, 143, 0.25);
+}
+
+.material-button.depleted {
+  opacity: 0.6;
+}
+
+.material-name {
+  font-weight: 600;
+}
+
+.material-amount {
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.crafting-bench-slots {
+  display: flex;
+  gap: 12px;
+}
+
+.bench-slot {
+  flex: 1;
+  min-height: 96px;
+  border: 1px dashed rgba(245, 212, 143, 0.35);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 12px;
+  background: rgba(34, 28, 23, 0.55);
+  text-align: center;
+}
+
+.bench-slot.filled {
+  border-style: solid;
+  border-color: rgba(245, 212, 143, 0.55);
+  background: rgba(245, 212, 143, 0.08);
+}
+
+.bench-item-name {
+  font-weight: 600;
+  text-align: center;
+}
+
+.bench-item-base {
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.bench-placeholder {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+.bench-material-info {
+  font-size: 0.85rem;
+  color: rgba(245, 212, 143, 0.75);
+}
+
+.crafting-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.crafting-controls button {
+  flex: 1 1 120px;
+}
+
+.crafting-last-result {
+  font-size: 0.8rem;
+  color: rgba(245, 212, 143, 0.7);
+}
+
+.crafting-item-stats-content {
+  background: rgba(18, 14, 11, 0.6);
+  border: 1px solid rgba(204, 172, 101, 0.25);
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bench-stats-list {
+  list-style: none;
+  padding: 0;
+  margin: 6px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: #dacfba;
 }
 
 .maps-list {


### PR DESCRIPTION
## Summary
- define dedicated equipment slots and item bases so weapons can occupy main hand, off-hand or quiver, including two-handed variants
- replace drag-and-drop equipment management with click-driven tooltips that show stats and offer equip, unequip, and bench actions
- build a crafting bench interface with material selection, craft controls, and an active item stat panel backed by new store logic and styles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdd4afd584832f932c768318e39c5a