### PR TITLE
Limit heroes to single map and redesign equipment grid

### DIFF
--- a/src/modules/equipment.js
+++ b/src/modules/equipment.js
@@ -8,6 +8,19 @@ const SLOT_LABELS = EQUIPMENT_SLOTS.reduce((map, slot) => {
   return map;
 }, {});
 
+const SLOT_AREAS = {
+  helmet: "helmet",
+  chest: "chest",
+  gloves: "gloves",
+  boots: "boots",
+  belt: "belt",
+  amulet: "amulet",
+  ring: "ring",
+  mainHand: "mainHand",
+  offHand: "offHand",
+  quiver: "quiver",
+};
+
 export class EquipmentPanel {
   constructor() {
     this.element = createElement("div", { className: "panel", attrs: { "data-area": "equipment" } });
@@ -58,6 +71,11 @@ export class EquipmentPanel {
         className: `equipment-slot${equippedItem ? " filled" : ""}`,
         attrs: { "data-slot": slot.id },
       });
+
+      const gridArea = SLOT_AREAS[slot.id];
+      if (gridArea) {
+        slotElement.style.gridArea = gridArea;
+      }
 
       const label = createElement("div", {
         className: "slot-label",

--- a/src/modules/maps.js
+++ b/src/modules/maps.js
@@ -32,6 +32,14 @@ const renderControls = (map, state) => {
     if (!state.activeHeroId) {
       runButton.disabled = true;
       runButton.title = "Select a hero from the guild to start this map.";
+    } else {
+      const heroBusy = state.maps.some(
+        (entry) => entry.status === "running" && entry.assignedHeroId === state.activeHeroId,
+      );
+      if (heroBusy) {
+        runButton.disabled = true;
+        runButton.title = "Selected hero is already running another map.";
+      }
     }
     runButton.addEventListener("click", () => actions.startMap(map.id, state.activeHeroId));
     controls.appendChild(runButton);

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -526,6 +526,13 @@ export const actions = {
       alert("Select a hero before starting a map.");
       return;
     }
+    const runningMap = state.maps.find(
+      (entry) => entry.status === "running" && entry.assignedHeroId === heroId,
+    );
+    if (runningMap) {
+      alert(`${hero.name} is already running another map.`);
+      return;
+    }
     state.maps = state.maps.map((map) => {
       if (map.id !== mapId) return map;
       if (map.status === "running") return map;

--- a/styles/main.css
+++ b/styles/main.css
@@ -247,12 +247,57 @@ button:disabled {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  align-items: center;
 }
 
 .equipment-grid {
+  position: relative;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 12px;
+  width: min(100%, 640px);
+  margin: 0 auto;
+  padding: 16px 24px;
+  background: linear-gradient(135deg, rgba(26, 20, 15, 0.9), rgba(40, 32, 24, 0.7));
+  border-radius: 14px;
+  border: 1px solid rgba(204, 172, 101, 0.25);
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.45);
+  grid-template-columns: repeat(5, minmax(100px, 1fr));
+  grid-template-rows: repeat(4, minmax(120px, auto));
+  grid-template-areas:
+    ". helmet amulet ring ."
+    "mainHand chest chest offHand quiver"
+    "mainHand gloves belt boots quiver"
+    ". gloves belt boots .";
+}
+
+.equipment-grid::before {
+  content: "";
+  position: absolute;
+  inset: 12% 30%;
+  border-radius: 40% / 45%;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(245, 212, 143, 0.12) 0%,
+    rgba(245, 212, 143, 0.05) 35%,
+    rgba(0, 0, 0, 0) 70%
+  );
+  pointer-events: none;
+  filter: blur(0.5px);
+}
+
+@media (max-width: 720px) {
+  .equipment-grid {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+    grid-template-rows: auto;
+    grid-template-areas:
+      "helmet helmet"
+      "amulet ring"
+      "mainHand offHand"
+      "chest chest"
+      "gloves boots"
+      "belt belt"
+      "quiver quiver";
+  }
 }
 
 .equipment-slot {
@@ -264,6 +309,9 @@ button:disabled {
   flex-direction: column;
   gap: 6px;
   min-height: 120px;
+  height: 100%;
+  align-items: center;
+  text-align: center;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 


### PR DESCRIPTION
## Summary
- prevent heroes from starting multiple map runs simultaneously and disable the run button when the selected hero is busy
- reorganize the equipment panel into a Path of Exile-inspired grid layout with responsive styling and ambient background
- map equipment slots to fixed grid areas so each slot consistently renders in the new layout

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdda9dc9bc832fa87b7af5c1e6e2ab